### PR TITLE
Update nso_config.py

### DIFF
--- a/plugins/modules/nso_config.py
+++ b/plugins/modules/nso_config.py
@@ -70,9 +70,9 @@ EXAMPLES = '''
           device-type:
             cli:
               ned-id: "cisco-ios-cli-6.44"
-            port: "22"
-            state:
-              admin-state: "unlocked"
+          port: "22"
+          state:
+            admin-state: "unlocked"
 
 - name: ADD NEW LOOPBACK
   cisco.nso.nso_config:


### PR DESCRIPTION
Examples have incorrect indents which cause the docs when generated to provide a non-working example.