### PR TITLE
ENG-36487: Add support for customizable output formats in the nso_config with input param result_as

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -10,7 +10,7 @@ v1.0.4
 Minor Changes
 -------------
 
-- nso_config can now handle additional input parameter i.e., result_as with choices like string and json.
+- nso_config can now handle additional input parameter i.e., result_as with choices like string and json.When result_as is set to string, the output will be in CLI format; otherwise, it will be in JSON format.
 
 
 v1.0.3

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,14 @@ Cisco NSO Ansible Collection Release Notes
 
 .. contents:: Topics
 
+v1.0.4
+======
+
+Minor Changes
+-------------
+
+- nso_config can now handle additional input parameter i.e., result_as with choices like string and json.
+
 
 v1.0.3
 ======

--- a/plugins/module_utils/nso.py
+++ b/plugins/module_utils/nso.py
@@ -181,13 +181,13 @@ class JsonRpc(object):
         resp, resp_json = self._write_call(payload)
         return resp_json['result']
 
-    def show_config(self, path, operational=False):
+    def show_config(self, path, operational=False, result_as = 'json'):
         payload = {
             'method': 'show_config',
             'params': {
                 'path': path,
-                'result_as': 'json',
-                'with_oper': operational}
+                'with_oper': operational,
+                'result_as': result_as,}
         }
         resp, resp_json = self._read_call(payload)
         return resp_json['result']

--- a/plugins/modules/nso_show.py
+++ b/plugins/modules/nso_show.py
@@ -97,23 +97,25 @@ class NsoShow(object):
         (3, 4, 12)
     ]
 
-    def __init__(self, check_mode, client, path, operational):
+    def __init__(self, check_mode, client, path, operational, result_as):
         self._check_mode = check_mode
         self._client = client
         self._path = path
         self._operational = operational
+        self.result_as = result_as
 
     def main(self):
         if self._check_mode:
             return {}
         else:
-            return self._client.show_config(self._path, self._operational)
+            return self._client.show_config(self._path, self._operational, self.result_as)
 
 
 def main():
     argument_spec = dict(
         path=dict(required=True, type='str'),
-        operational=dict(required=False, type='bool', default=False)
+        operational=dict(required=False, type='bool', default=False),
+        result_as=dict(required=False, type='str', default='json'),
     )
     argument_spec.update(nso_argument_spec)
 
@@ -126,7 +128,7 @@ def main():
     client = connect(p)
     nso_show = NsoShow(
         module.check_mode, client,
-        p['path'], p['operational'])
+        p['path'], p['operational']), p['result_as']
     try:
         verify_version(client, NsoShow.REQUIRED_VERSIONS)
 

--- a/tests/unit/plugins/modules/test_nso_show.py
+++ b/tests/unit/plugins/modules/test_nso_show.py
@@ -61,7 +61,7 @@ class TestNsoShow(nso_module.TestNsoModule):
             MockResponse('get_system_setting', {'operation': 'version'}, 200, '{"result": "4.5"}'),
             MockResponse('new_trans', {'mode': 'read'}, 200, '{"result": {"th": 1}}'),
             MockResponse('show_config', {'path': path, 'result_as': 'json'}, 200, '{"result": {"data": {}}}'),
-            MockResponse('show_config', {'path': path, 'result_as': 'string'}, 200, '{"result": {"config": {}}}'),
+            MockResponse('show_config', {'path': path, 'result_as': 'string'}, 200, '{"result": {"config": ""}}'),
             MockResponse('logout', {}, 200, '{"result": {}}'),
         ]
         open_url_mock.side_effect = lambda *args, **kwargs: nso_module.mock_call(calls, *args, **kwargs)
@@ -83,7 +83,7 @@ class TestNsoShow(nso_module.TestNsoModule):
             MockResponse('get_system_setting', {'operation': 'version'}, 200, '{"result": "4.5"}'),
             MockResponse('new_trans', {'mode': 'read'}, 200, '{"result": {"th": 1}}'),
             MockResponse('show_config', {'path': path, 'result_as': 'json'}, 200, '{"result": {"data": {}}}'),
-            MockResponse('show_config', {'path': path, 'result_as': 'string'}, 200, '{"result": {"config": {}}}'),
+            MockResponse('show_config', {'path': path, 'result_as': 'string'}, 200, '{"result": {"config": ""}}'),
             MockResponse('logout', {}, 200, '{"result": {}}'),
         ]
         open_url_mock.side_effect = lambda *args, **kwargs: nso_module.mock_call(calls, *args, **kwargs)

--- a/tests/unit/plugins/modules/test_nso_show.py
+++ b/tests/unit/plugins/modules/test_nso_show.py
@@ -61,6 +61,7 @@ class TestNsoShow(nso_module.TestNsoModule):
             MockResponse('get_system_setting', {'operation': 'version'}, 200, '{"result": "4.5"}'),
             MockResponse('new_trans', {'mode': 'read'}, 200, '{"result": {"th": 1}}'),
             MockResponse('show_config', {'path': path, 'result_as': 'json'}, 200, '{"result": {"data": {}}}'),
+            MockResponse('show_config', {'path': path, 'result_as': 'string'}, 200, '{"result": {"config": {}}}'),
             MockResponse('logout', {}, 200, '{"result": {}}'),
         ]
         open_url_mock.side_effect = lambda *args, **kwargs: nso_module.mock_call(calls, *args, **kwargs)
@@ -82,6 +83,7 @@ class TestNsoShow(nso_module.TestNsoModule):
             MockResponse('get_system_setting', {'operation': 'version'}, 200, '{"result": "4.5"}'),
             MockResponse('new_trans', {'mode': 'read'}, 200, '{"result": {"th": 1}}'),
             MockResponse('show_config', {'path': path, 'result_as': 'json'}, 200, '{"result": {"data": {}}}'),
+            MockResponse('show_config', {'path': path, 'result_as': 'string'}, 200, '{"result": {"config": {}}}'),
             MockResponse('logout', {}, 200, '{"result": {}}'),
         ]
         open_url_mock.side_effect = lambda *args, **kwargs: nso_module.mock_call(calls, *args, **kwargs)


### PR DESCRIPTION
### Additional Parameter Changes

- Modified the changes related to show_config method - parameter addition in show_config method i.e.,  result_as
- Adding a additional parameter to show the result/output in either in json or cli format
- When result_as is set to string, the output will be in CLI format; otherwise, it will be in JSON format.
- In result_as parameter user can use either string or json value when creating a Ansible playbook.
